### PR TITLE
fix(stripping): DVT-2 add support for keeping the code when stripping

### DIFF
--- a/Editor/LinkXmlAutoGenerator.cs
+++ b/Editor/LinkXmlAutoGenerator.cs
@@ -1,0 +1,52 @@
+using System.IO;
+using UnityEditor;
+using UnityEditor.Build;
+using UnityEditor.Build.Reporting;
+
+namespace PlayerZero.Editor
+{
+    public class LinkXmlAutoGenerator : IPreprocessBuildWithReport
+    {
+        public int callbackOrder => 0;
+
+        private const string FolderPath = "Assets/PlayerZero";
+        
+        private const string LinkXmlFile = "link.xml";
+
+        public void OnPreprocessBuild(BuildReport report)
+        {
+            var targetGroup = BuildPipeline.GetBuildTargetGroup(report.summary.platform);
+            
+            if (!PlayerSettings.stripEngineCode && PlayerSettings.GetManagedStrippingLevel(targetGroup) == ManagedStrippingLevel.Disabled)
+            {
+                UnityEngine.Debug.LogWarning(
+                    "[LinkXmlAutoGenerator] Managed Stripping Level is set to Disabled. link.xml is not required.");
+                return;
+            }
+
+            if (!Directory.Exists(FolderPath))
+            {
+                UnityEngine.Debug.Log($"Creating folder: {FolderPath}");
+                Directory.CreateDirectory(FolderPath);
+            }
+
+            var linkXmlPath = Path.Combine(FolderPath, LinkXmlFile);
+            
+            if (File.Exists(linkXmlPath))
+            {
+                UnityEngine.Debug.Log($"[LinkXmlAutoGenerator] link.xml already exists at: {linkXmlPath}. Be sure to preserve PlayerZero.Api* types.");
+                return;
+            }
+
+            string xmlContent = @"<linker>
+    <assembly fullname=""PlayerZero.Runtime"">
+        <type fullname=""PlayerZero.Api*"" preserve=""all""/>
+    </assembly>
+</linker>";
+
+            File.WriteAllText(linkXmlPath, xmlContent);
+            UnityEngine.Debug.Log($"[LinkXmlAutoGenerator] Created link.xml to preserve PlayerZero.Api* types:\n{linkXmlPath}");
+            AssetDatabase.Refresh();
+        }
+    }
+}

--- a/Editor/LinkXmlAutoGenerator.cs.meta
+++ b/Editor/LinkXmlAutoGenerator.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: ecce26d2c0be42358d3966729ad895c3
+timeCreated: 1742907575

--- a/Runtime/Api/V1/GameEvents/Models/DeviceContext.cs
+++ b/Runtime/Api/V1/GameEvents/Models/DeviceContext.cs
@@ -1,6 +1,6 @@
 using Newtonsoft.Json;
 
-namespace PlayerZero
+namespace PlayerZero.Api.V1
 {
     [System.Serializable]
     public class DeviceContext

--- a/Runtime/DeviceAnalytics.cs
+++ b/Runtime/DeviceAnalytics.cs
@@ -1,5 +1,6 @@
 using System;
 using Newtonsoft.Json;
+using PlayerZero.Api.V1;
 using UnityEngine;
 #if UNITY_WEBGL && !UNITY_EDITOR
 using System.Runtime.InteropServices;


### PR DESCRIPTION
When stripping is set to High (on WebGL builds) we noticed that JSON types were ignored, that happens mostly with analytics events but also on the avatar request.

![image](https://github.com/user-attachments/assets/93935cd0-f511-4caa-a95f-2824e55203b0)


To avoid that we're creating a [link.xml](https://docs.unity3d.com/6000.0/Documentation/Manual/managed-code-stripping-xml-formatting.html) on every build to keep every player-zero deps only when the stripping is enabled. That file we be located on PlayerZero folder 

![image](https://github.com/user-attachments/assets/9ef82572-c381-4f7f-b82d-21e816c9345b)

Unity will search any link.xml under Asset folder and will be included and respected, the final build then looks like 

![image](https://github.com/user-attachments/assets/1a606dd4-ba20-4895-b7fb-5a8df0a20851)

