### PR TITLE
[DVT-130] added cached hotloaded ID and ZeroQueryParams class

### DIFF
--- a/Runtime/DeepLinking/DeepLinkHandler.cs
+++ b/Runtime/DeepLinking/DeepLinkHandler.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using UnityEngine;
 
 namespace PlayerZero.Runtime.DeepLinking
@@ -15,7 +14,6 @@ namespace PlayerZero.Runtime.DeepLinking
         private  const string USER_NAME_KEY = "userName";
         
         private static DeepLinkData data;
-        private static Dictionary<string, string> parameters = new Dictionary<string, string>();
 
         static DeepLinkHandler()
         {
@@ -25,16 +23,9 @@ namespace PlayerZero.Runtime.DeepLinking
         private static void OnDeepLinkActivated(string url)
         {
             DeeplinkURL = url;
-            parameters.Clear();
             if (url.Contains(LINK_NAME))
             {
-                var uri = new Uri(url);
-                var query = System.Web.HttpUtility.ParseQueryString(uri.Query);
-                foreach (var key in query.AllKeys)
-                {
-                    parameters[key] = query[key];
-                }
-                
+                var parameters = ZeroQueryParams.GetParams();
                 if (parameters.TryGetValue(AVATAR_ID_KEY, out var avatarId))
                 {
                     data.AvatarId = avatarId;
@@ -43,8 +34,10 @@ namespace PlayerZero.Runtime.DeepLinking
                 {
                     data.UserName = userName;
                 }
+                OnDeepLinkDataReceived.Invoke(data);
+                return;
             }
-            OnDeepLinkDataReceived.Invoke(data);
+            Debug.LogWarning($"No Deeplink data found at URL: {url}");
         }
     }
 }

--- a/Runtime/Sdk/PlayerZeroSdk.cs
+++ b/Runtime/Sdk/PlayerZeroSdk.cs
@@ -212,5 +212,10 @@ namespace PlayerZero.Runtime.Sdk
             PlayerPrefs.SetString(CACHED_AVATAR_ID, avatarId);
             OnHotLoadedAvatarIdChanged?.Invoke(avatarId);
         }
+        
+        public static void ClearCachedAvatarId()
+        {
+            PlayerPrefs.DeleteKey(CACHED_AVATAR_ID);
+        }
     }
 }

--- a/Runtime/ZeroQueryParams.cs
+++ b/Runtime/ZeroQueryParams.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace PlayerZero.Runtime.DeepLinking
+{
+    public static class ZeroQueryParams
+    {
+        private static Dictionary<string, string> _queryParameters = new Dictionary<string, string>();
+        
+        /// <summary>
+        /// Returns all query parameters from the current URL.
+        /// </summary>
+        public static Dictionary<string, string> GetParams()
+        {
+            return GetParams(Application.absoluteURL);
+        }
+
+        /// <summary>
+        /// Returns only the specified query parameters.
+        /// Logs a warning for any requested keys that are not present.
+        /// </summary>
+        public static Dictionary<string, string> GetSelectedParams(params string[] keys)
+        {
+            var allParams = GetParams(Application.absoluteURL);
+            var selectedParams = new Dictionary<string, string>();
+
+            foreach (var key in keys)
+            {
+                if (allParams.TryGetValue(key, out var value))
+                {
+                    selectedParams[key] = value;
+                }
+                else
+                {
+                    Debug.LogWarning($"Query parameter '{key}' not found in URL.");
+                }
+            }
+
+            return selectedParams;
+        }
+
+        /// <summary>
+        /// Parses query parameters from the given URL.
+        /// </summary>
+        private static Dictionary<string, string> GetParams(string url)
+        {
+            if (string.IsNullOrEmpty(url))
+                return _queryParameters;
+
+            var uri = new Uri(url);
+            var query = uri.Query;
+
+            if (string.IsNullOrEmpty(query))
+                return _queryParameters;
+
+            var queryParamsArray = query.TrimStart('?').Split('&');
+
+            foreach (var param in queryParamsArray)
+            {
+                var keyValue = param.Split('=');
+                if (keyValue.Length != 2) continue;
+
+                var key = Uri.UnescapeDataString(keyValue[0]);
+                var value = Uri.UnescapeDataString(keyValue[1]);
+
+                _queryParameters[key] = value;
+            }
+
+            return _queryParameters;
+        }
+    }
+}

--- a/Runtime/ZeroQueryParams.cs.meta
+++ b/Runtime/ZeroQueryParams.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1a47d5ee26af99e4a830e1f0a52dd2f3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
<!-- Copy the TICKETID for this task from Jira and add it to the PR name in brackets -->
<!-- PR name should look like: [TICKETID] My Pull Request -->

<!-- Add link for the ticket here editing the TICKETID-->

## [DVT-130](https://ready-player-me.atlassian.net/browse/DVT-130)

## Description

-   This PR adds hotloaded avatar ID caching so that after initial deeplink the avatar ID will be there for later runs of the game. 
- I also added a ZeroQueryParam class for handling parameter extraction from URL's to reduce code duplication. 

<!-- Fill the section below with Added, Updated and Removed information. -->
<!-- If there is no item under one of the lists remove it's title. -->

<!-- Testability -->

## How to Test

-   If you were to make a build and launch the game from a deeplink, or webgl with avatarID param, when you launch the game again with no avatarID it should load the avatar of the previous avatarId

<!-- Update your progress with the task here -->

## Checklist

-   [ ] Tests written or updated for the changes.
-   [ ] Documentation is updated.
-   [ ] Changelog is updated.

<!--- Remember to copy the Changes Section into the commit message when you close the PR -->





[DVT-130]: https://ready-player-me.atlassian.net/browse/DVT-130?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ