### PR TITLE
[DVT-208] feat: added token to events

### DIFF
--- a/Runtime/Api/V1/GameEvents/Contracts/IGameEvent.cs
+++ b/Runtime/Api/V1/GameEvents/Contracts/IGameEvent.cs
@@ -1,7 +1,10 @@
-﻿namespace PlayerZero.Api.V1.Contracts
+﻿using Newtonsoft.Json;
+
+namespace PlayerZero.Api.V1.Contracts
 {
     public interface IGameEvent<T> where T : class, IGameSession
     {
         T Properties { get; set; }
+        string Token { get; set; }
     }
 }

--- a/Runtime/Api/V1/GameEvents/Events/AvatarSessionEndedEvent.cs
+++ b/Runtime/Api/V1/GameEvents/Events/AvatarSessionEndedEvent.cs
@@ -10,6 +10,9 @@ namespace PlayerZero.Api.V1
         
         [JsonProperty("properties")]
         public AvatarSessionEndedProperties Properties { get; set; }
+        
+        [JsonProperty("token")]
+        public string Token { get; set; }
     }
     
     public class AvatarSessionEndedProperties : IGameSession, IGame

--- a/Runtime/Api/V1/GameEvents/Events/AvatarSessionHeartbeatEvent.cs
+++ b/Runtime/Api/V1/GameEvents/Events/AvatarSessionHeartbeatEvent.cs
@@ -10,6 +10,9 @@ namespace PlayerZero.Api.V1
         
         [JsonProperty("properties")]
         public AvatarSessionHeartbeatProperties Properties { get; set; }
+        
+        [JsonProperty("token")]
+        public string Token { get; set; }
     }
     
     public class AvatarSessionHeartbeatProperties : IGameSession, IGame

--- a/Runtime/Api/V1/GameEvents/Events/AvatarSessionStartedEvent.cs
+++ b/Runtime/Api/V1/GameEvents/Events/AvatarSessionStartedEvent.cs
@@ -10,6 +10,9 @@ namespace PlayerZero.Api.V1
         
         [JsonProperty("properties")]
         public AvatarSessionStartedProperties Properties { get; set; }
+        
+        [JsonProperty("token")]
+        public string Token { get; set; }
     }
     
     public class AvatarSessionStartedProperties : IGameSession, IGame

--- a/Runtime/Api/V1/GameEvents/Events/GameMatchEndedEvent.cs
+++ b/Runtime/Api/V1/GameEvents/Events/GameMatchEndedEvent.cs
@@ -11,6 +11,9 @@ namespace PlayerZero.Api.V1
         
         [JsonProperty("properties")]
         public GameMatchEndedProperties Properties { get; set; }
+        
+        [JsonProperty("token")]
+        public string Token { get; set; }
     }
 
     public class GameMatchEndedProperties : IGameSession, IGame

--- a/Runtime/Api/V1/GameEvents/Events/GameMatchStartedEvent.cs
+++ b/Runtime/Api/V1/GameEvents/Events/GameMatchStartedEvent.cs
@@ -11,6 +11,9 @@ namespace PlayerZero.Api.V1
         
         [JsonProperty("properties")]
         public GameMatchStartedProperties Properties { get; set; }
+        
+        [JsonProperty("token")]
+        public string Token { get; set; }
     }
     
     public class GameMatchStartedProperties : IGameSession, IGame

--- a/Runtime/Api/V1/GameEvents/Events/GameSessionEndedEvent.cs
+++ b/Runtime/Api/V1/GameEvents/Events/GameSessionEndedEvent.cs
@@ -11,6 +11,9 @@ namespace PlayerZero.Api.V1
         
         [JsonProperty("properties")]
         public GameSessionEndedProperties Properties { get; set; }
+        
+        [JsonProperty("token")]
+        public string Token { get; set; }
     }
     
     public class GameSessionEndedProperties : IGameSession, IGame

--- a/Runtime/Api/V1/GameEvents/Events/GameSessionStartedEvent.cs
+++ b/Runtime/Api/V1/GameEvents/Events/GameSessionStartedEvent.cs
@@ -10,6 +10,8 @@ namespace PlayerZero.Api.V1
         
         [JsonProperty("properties")]
         public GameSessionStartedProperties Properties { get; set; }
+
+        public string Token { get; set; }
     }
     
     public class GameSessionStartedProperties : IGameSession, IGame

--- a/Runtime/Api/V1/GameEvents/GameEventApi.cs
+++ b/Runtime/Api/V1/GameEvents/GameEventApi.cs
@@ -1,30 +1,40 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using PlayerZero.Api.V1.Contracts;
+using PlayerZero.Runtime.DeepLinking;
 using UnityEngine.Networking;
 
 namespace PlayerZero.Api.V1
 {
     public class GameEventApi : WebApi
     {
+        private const string PZ_TOKEN_PARAM = "token";
         private const string Resource = "public/events";
         
         /// <summary>
         /// Sends a generic game event to the analytics server asynchronously.
         /// </summary>
         /// <typeparam name="T">The type of the payload.</typeparam>
+        /// <typeparam name="TEventProperties"></typeparam>
         /// <param name="request">The event data to send.</param>
-        public async Task SendGameEventAsync<T>(T request)
+        public async Task SendGameEventAsync<T, TEventProperties>(T request)
+            where T : IGameEvent<TEventProperties>
+            where TEventProperties : class, IGameSession
         {
-            var apiRequest = new ApiRequest<T>()
+            var token = ZeroQueryParams.GetParams().TryGetValue(PZ_TOKEN_PARAM, out var tokenValue) ? tokenValue : string.Empty;
+            request.Token = token;
+
+            var apiRequest = new ApiRequest<T>
             {
                 Url = $"{Settings.ApiBaseUrl}/v1/{Resource}",
                 Method = UnityWebRequest.kHttpVerbPOST,
-                Headers = new Dictionary<string, string>()
+                Headers = new Dictionary<string, string>
                 {
                     { "Content-Type", "application/json" },
                 },
                 Payload = request
             };
+
             await Dispatch<GameEventResponse, T>(apiRequest);
         }
     }

--- a/Runtime/Sdk/PlayerZeroAnalytics.cs
+++ b/Runtime/Sdk/PlayerZeroAnalytics.cs
@@ -36,7 +36,7 @@ namespace PlayerZero.Runtime.Sdk
                 Debug.LogError("Player Zero Game ID is required. Please set it in tools -> Player Zero.");
                 return;
             }
-
+            
             if (_instance == null || _instance == this)
             {
 #if ENABLE_INPUT_SYSTEM

--- a/Runtime/Sdk/PlayerZeroSdk.cs
+++ b/Runtime/Sdk/PlayerZeroSdk.cs
@@ -106,7 +106,7 @@ namespace PlayerZero.Runtime.Sdk
             var sessionId = Guid.NewGuid().ToString();
             eventPayload.Properties.SessionId = sessionId;
             eventPayload.Properties.GameId = _settings.GameId;
-            _gameEventApi.SendGameEventAsync(eventPayload)
+            _gameEventApi.SendGameEventAsync<TEvent, TEventProperties>(eventPayload)
                 .ContinueWith(eventResponse =>
                 {
                     if (eventResponse.Status != TaskStatus.RanToCompletion)
@@ -126,7 +126,7 @@ namespace PlayerZero.Runtime.Sdk
 
             eventPayload.Properties.GameId = _settings.GameId;
             
-            _gameEventApi.SendGameEventAsync(eventPayload)
+            _gameEventApi.SendGameEventAsync<TEvent, TEventProperties>(eventPayload)
                 .ContinueWith(eventResponse =>
                 {
                     if (eventResponse.Status != TaskStatus.RanToCompletion)


### PR DESCRIPTION
<!-- Copy the TICKETID for this task from Jira and add it to the PR name in brackets -->
<!-- PR name should look like: [TICKETID] My Pull Request -->

<!-- Add link for the ticket here editing the TICKETID-->

## [DVT-208](https://ready-player-me.atlassian.net/browse/DVT-208)

## Description

-  this PR adds support for reading and sending the generated token in game analytics event, this was requested by pzero team. 
- The generated token is used as a way to verify analytics events if I remember correctly it is passed from pzero as a query param in the url (deeplink) 




<!-- Fill the section below with Added, Updated and Removed information. -->
<!-- If there is no item under one of the lists remove it's title. -->

<!-- Testability -->

## How to Test

-   Easiest way to test would be to make a build for webgl, and add a token=000000 param and check that it is sent in analytics events. 

<!-- Update your progress with the task here -->

## Checklist

-   [ ] Tests written or updated for the changes.
-   [ ] Documentation is updated.
-   [ ] Changelog is updated.

<!--- Remember to copy the Changes Section into the commit message when you close the PR -->





[DVT-208]: https://ready-player-me.atlassian.net/browse/DVT-208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ