### PR TITLE
[DVT-233] feat: add shader variants to sdk

### DIFF
--- a/Runtime/Shaders.meta
+++ b/Runtime/Shaders.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bf04a61831295c848ae2c6c155828065
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Shaders/PlayerZeroShaders.shadervariants
+++ b/Runtime/Shaders/PlayerZeroShaders.shadervariants
@@ -1,0 +1,106 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!200 &20000000
+ShaderVariantCollection:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: PlayerZeroShaders
+  m_Shaders:
+  - first: {fileID: 4800000, guid: 99fa998bbbed3408aafa652b466d261d, type: 3}
+    second:
+      variants:
+      - keywords: DIRECTIONAL LIGHTPROBE_SH
+        passType: 4
+      - keywords: DIRECTIONAL LIGHTPROBE_SH _ALPHATEST_ON
+        passType: 4
+      - keywords: DIRECTIONAL LIGHTPROBE_SH _ALPHABLEND_ON
+        passType: 4
+      - keywords: DIRECTIONAL LIGHTPROBE_SH _METALLICGLOSSMAP
+        passType: 4
+      - keywords: DIRECTIONAL LIGHTPROBE_SH _EMISSION _METALLICGLOSSMAP
+        passType: 4
+      - keywords: DIRECTIONAL LIGHTPROBE_SH _METALLICGLOSSMAP _NORMALMAP
+        passType: 4
+      - keywords: DIRECTIONAL LIGHTPROBE_SH _EMISSION _METALLICGLOSSMAP _NORMALMAP
+        passType: 4
+      - keywords: DIRECTIONAL LIGHTPROBE_SH _ALPHATEST_ON _METALLICGLOSSMAP _NORMALMAP
+        passType: 4
+      - keywords: DIRECTIONAL LIGHTPROBE_SH _ALPHABLEND_ON _METALLICGLOSSMAP _NORMALMAP
+        passType: 4
+      - keywords: DIRECTIONAL LIGHTPROBE_SH _ALPHABLEND_ON _EMISSION _METALLICGLOSSMAP
+          _NORMALMAP
+        passType: 4
+      - keywords: DIRECTIONAL LIGHTPROBE_SH _METALLICGLOSSMAP _NORMALMAP _OCCLUSION
+        passType: 4
+      - keywords: DIRECTIONAL LIGHTPROBE_SH _EMISSION _METALLICGLOSSMAP _NORMALMAP
+          _OCCLUSION
+        passType: 4
+      - keywords: DIRECTIONAL LIGHTPROBE_SH _TEXTURE_TRANSFORM
+        passType: 4
+      - keywords: DIRECTIONAL LIGHTPROBE_SH _ALPHABLEND_ON _METALLICGLOSSMAP _NORMALMAP
+          _TEXTURE_TRANSFORM
+        passType: 4
+      - keywords: DIRECTIONAL
+        passType: 5
+      - keywords: DIRECTIONAL _ALPHATEST_ON
+        passType: 5
+      - keywords: DIRECTIONAL _ALPHABLEND_ON
+        passType: 5
+      - keywords: DIRECTIONAL _METALLICGLOSSMAP
+        passType: 5
+      - keywords: DIRECTIONAL _METALLICGLOSSMAP _NORMALMAP
+        passType: 5
+      - keywords: DIRECTIONAL _ALPHATEST_ON _METALLICGLOSSMAP _NORMALMAP
+        passType: 5
+      - keywords: DIRECTIONAL _ALPHABLEND_ON _METALLICGLOSSMAP _NORMALMAP
+        passType: 5
+      - keywords: DIRECTIONAL _METALLICGLOSSMAP _NORMALMAP _OCCLUSION
+        passType: 5
+      - keywords: DIRECTIONAL _TEXTURE_TRANSFORM
+        passType: 5
+      - keywords: DIRECTIONAL _ALPHABLEND_ON _METALLICGLOSSMAP _NORMALMAP _TEXTURE_TRANSFORM
+        passType: 5
+      - keywords: SHADOWS_DEPTH
+        passType: 8
+      - keywords: SHADOWS_DEPTH _ALPHATEST_ON
+        passType: 8
+      - keywords: SHADOWS_DEPTH _ALPHABLEND_ON
+        passType: 8
+      - keywords: SHADOWS_DEPTH _METALLICGLOSSMAP
+        passType: 8
+      - keywords: SHADOWS_DEPTH _ALPHATEST_ON _METALLICGLOSSMAP
+        passType: 8
+      - keywords: SHADOWS_DEPTH _ALPHABLEND_ON _METALLICGLOSSMAP
+        passType: 8
+      - keywords: SHADOWS_DEPTH _METALLICGLOSSMAP _OCCLUSION
+        passType: 8
+      - keywords: SHADOWS_DEPTH _TEXTURE_TRANSFORM
+        passType: 8
+      - keywords: SHADOWS_DEPTH _ALPHABLEND_ON _METALLICGLOSSMAP _TEXTURE_TRANSFORM
+        passType: 8
+      - keywords: LIGHTPROBE_SH UNITY_HDR_ON
+        passType: 10
+      - keywords: LIGHTPROBE_SH UNITY_HDR_ON _ALPHATEST_ON
+        passType: 10
+      - keywords: LIGHTPROBE_SH UNITY_HDR_ON _METALLICGLOSSMAP
+        passType: 10
+      - keywords: LIGHTPROBE_SH UNITY_HDR_ON _METALLICGLOSSMAP _NORMALMAP
+        passType: 10
+      - keywords: LIGHTPROBE_SH UNITY_HDR_ON _EMISSION _METALLICGLOSSMAP _NORMALMAP
+        passType: 10
+      - keywords: LIGHTPROBE_SH UNITY_HDR_ON _ALPHATEST_ON _METALLICGLOSSMAP _NORMALMAP
+        passType: 10
+      - keywords: LIGHTPROBE_SH UNITY_HDR_ON _METALLICGLOSSMAP _NORMALMAP _OCCLUSION
+        passType: 10
+      - keywords: LIGHTPROBE_SH UNITY_HDR_ON _EMISSION _METALLICGLOSSMAP _NORMALMAP
+          _OCCLUSION
+        passType: 10
+      - keywords: LIGHTPROBE_SH UNITY_HDR_ON _TEXTURE_TRANSFORM
+        passType: 10
+  - first: {fileID: 4800000, guid: 4340a3cf1cde6416d957808a6ac79eed, type: 3}
+    second:
+      variants:
+      - keywords: 
+        passType: 0

--- a/Runtime/Shaders/PlayerZeroShaders.shadervariants.meta
+++ b/Runtime/Shaders/PlayerZeroShaders.shadervariants.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6ab3f9327d29a774a9dc1dcb05447f7a
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 20000000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Shaders/PlayerZeroShadersHDRP.shadervariants
+++ b/Runtime/Shaders/PlayerZeroShadersHDRP.shadervariants
@@ -1,0 +1,58 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!200 &20000000
+ShaderVariantCollection:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: PlayerZeroShadersHDRP
+  m_Shaders:
+  - first: {fileID: -6465566751694194690, guid: f06cd296b834444abb6dbc0acccf9414,
+      type: 3}
+    second:
+      variants:
+      - keywords: 
+        passType: 8
+      - keywords: _TEXTURE_TRANSFORM
+        passType: 8
+      - keywords: _EMISSIVE
+        passType: 8
+      - keywords: DECALS_3RT SHADOW_MEDIUM USE_CLUSTERED_LIGHTLIST _TEXTURE_TRANSFORM
+        passType: 13
+      - keywords: _EMISSIVE
+        passType: 13
+      - keywords: DECALS_3RT SHADOW_MEDIUM USE_CLUSTERED_LIGHTLIST _EMISSIVE
+        passType: 13
+  - first: {fileID: -6465566751694194690, guid: ba6d401c74b2c4f96af7edf0fe32241e,
+      type: 3}
+    second:
+      variants:
+      - keywords: 
+        passType: 8
+      - keywords: 
+        passType: 13
+      - keywords: DECALS_3RT
+        passType: 13
+  - first: {fileID: -6465566751694194690, guid: 90c26dfde11bf4ff69ef936c6e6b1ed1,
+      type: 3}
+    second:
+      variants:
+      - keywords: 
+        passType: 8
+      - keywords: _EMISSIVE
+        passType: 8
+      - keywords: _TEXTURE_TRANSFORM
+        passType: 8
+      - keywords: 
+        passType: 13
+      - keywords: DECALS_3RT
+        passType: 13
+      - keywords: _EMISSIVE
+        passType: 13
+      - keywords: DECALS_3RT _EMISSIVE
+        passType: 13
+      - keywords: _TEXTURE_TRANSFORM
+        passType: 13
+      - keywords: DECALS_3RT _TEXTURE_TRANSFORM
+        passType: 13

--- a/Runtime/Shaders/PlayerZeroShadersHDRP.shadervariants.meta
+++ b/Runtime/Shaders/PlayerZeroShadersHDRP.shadervariants.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8decff1be696fd64ab6e7f1086faa34c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Shaders/PlayerZeroShadersURP.shadervariants
+++ b/Runtime/Shaders/PlayerZeroShadersURP.shadervariants
@@ -1,0 +1,74 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!200 &20000000
+ShaderVariantCollection:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: PlayerZeroShadersURP
+  m_Shaders:
+  - first: {fileID: -6465566751694194690, guid: f06cd296b834444abb6dbc0acccf9414,
+      type: 3}
+    second:
+      variants:
+      - keywords: 
+        passType: 8
+      - keywords: _TEXTURE_TRANSFORM
+        passType: 8
+      - keywords: _EMISSIVE
+        passType: 8
+      - keywords: _ADDITIONAL_LIGHTS _TEXTURE_TRANSFORM
+        passType: 13
+      - keywords: _ADDITIONAL_LIGHTS_VERTEX _MAIN_LIGHT_SHADOWS _MAIN_LIGHT_SHADOWS_CASCADE
+          _SHADOWS_SOFT _TEXTURE_TRANSFORM
+        passType: 13
+      - keywords: _ADDITIONAL_LIGHTS _EMISSIVE
+        passType: 13
+      - keywords: _ADDITIONAL_LIGHTS_VERTEX _EMISSIVE _MAIN_LIGHT_SHADOWS _MAIN_LIGHT_SHADOWS_CASCADE
+          _SHADOWS_SOFT
+        passType: 13
+  - first: {fileID: -6465566751694194690, guid: ba6d401c74b2c4f96af7edf0fe32241e,
+      type: 3}
+    second:
+      variants:
+      - keywords: 
+        passType: 8
+      - keywords: 
+        passType: 13
+      - keywords: _ADDITIONAL_LIGHTS
+        passType: 13
+      - keywords: _ADDITIONAL_LIGHTS_VERTEX _MAIN_LIGHT_SHADOWS _MAIN_LIGHT_SHADOWS_CASCADE
+          _SHADOWS_SOFT
+        passType: 13
+  - first: {fileID: -6465566751694194690, guid: 90c26dfde11bf4ff69ef936c6e6b1ed1,
+      type: 3}
+    second:
+      variants:
+      - keywords: 
+        passType: 8
+      - keywords: _EMISSIVE
+        passType: 8
+      - keywords: _TEXTURE_TRANSFORM
+        passType: 8
+      - keywords: 
+        passType: 13
+      - keywords: _ADDITIONAL_LIGHTS
+        passType: 13
+      - keywords: _ADDITIONAL_LIGHTS_VERTEX _MAIN_LIGHT_SHADOWS _MAIN_LIGHT_SHADOWS_CASCADE
+          _SHADOWS_SOFT
+        passType: 13
+      - keywords: _EMISSIVE
+        passType: 13
+      - keywords: _ADDITIONAL_LIGHTS _EMISSIVE
+        passType: 13
+      - keywords: _ADDITIONAL_LIGHTS_VERTEX _EMISSIVE _MAIN_LIGHT_SHADOWS _MAIN_LIGHT_SHADOWS_CASCADE
+          _SHADOWS_SOFT
+        passType: 13
+      - keywords: _TEXTURE_TRANSFORM
+        passType: 13
+      - keywords: _ADDITIONAL_LIGHTS _TEXTURE_TRANSFORM
+        passType: 13
+      - keywords: _ADDITIONAL_LIGHTS_VERTEX _MAIN_LIGHT_SHADOWS _MAIN_LIGHT_SHADOWS_CASCADE
+          _SHADOWS_SOFT _TEXTURE_TRANSFORM
+        passType: 13

--- a/Runtime/Shaders/PlayerZeroShadersURP.shadervariants.meta
+++ b/Runtime/Shaders/PlayerZeroShadersURP.shadervariants.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2cc9a621ad3050e479d823762fbfd13c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
<!-- Copy the TICKETID for this task from Jira and add it to the PR name in brackets -->
<!-- PR name should look like: [TICKETID] My Pull Request -->

<!-- Add link for the ticket here editing the TICKETID-->

## [DVT-233](https://ready-player-me.atlassian.net/browse/DVT-233)

## Description

-   This PR adds shader varients assets to sdk. These can be added to the Graphics > Preloaded shaders setting to prevent avatar and material loading issues. 


<!-- Fill the section below with Added, Updated and Removed information. -->
<!-- If there is no item under one of the lists remove it's title. -->

<!-- Testability -->

## How to Test

-   A bit tricky to test. But if you have an avatar ID of an avatar that has an alpha blend material (for example), then it will load incorrectly in builds without these shader variants included. 

<!-- Update your progress with the task here -->

## Checklist

-   [ ] Tests written or updated for the changes.
-   [ ] Documentation is updated.
-   [ ] Changelog is updated.

<!--- Remember to copy the Changes Section into the commit message when you close the PR -->





[DVT-233]: https://ready-player-me.atlassian.net/browse/DVT-233?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ